### PR TITLE
Allow Multiple Config Classes for Each Type

### DIFF
--- a/src/Project.php
+++ b/src/Project.php
@@ -217,11 +217,31 @@ class Project
         $mode = $this->mode;
 
         if (isset($config->common)) {
-            $this->config_classes[$type][] = $config->common;
+            $this->addConfigClassesToType($type, $config->common);
         }
 
         if (isset($config->$mode)) {
-            $this->config_classes[$type][] = $config->$mode;
+            $this->addConfigClassesToType($type, $config->$mode);
         }
+    }
+
+    /**
+     *
+     * Add a series of config classes to the given type array.
+     *
+     * @param string $type The type to add the configuration classes to
+     *
+     * @param array|string $classes A single class to add or an array of classes to add.
+     *
+     * @return null
+     *
+     */
+    protected function addConfigClassesToType($type, $classes)
+    {
+        if (! is_array($classes)) {
+            $classes = array($classes);
+        }
+
+        $this->config_classes[$type] = array_merge($this->config_classes[$type], $classes);
     }
 }

--- a/src/Project.php
+++ b/src/Project.php
@@ -238,10 +238,10 @@ class Project
      */
     protected function addConfigClassesToType($type, $classes)
     {
-        if (! is_array($classes)) {
+        if (is_string($classes)) {
             $classes = array($classes);
         }
 
-        $this->config_classes[$type] = array_merge($this->config_classes[$type], $classes);
+        $this->config_classes[$type] = array_merge($this->config_classes[$type], (array)$classes);
     }
 }

--- a/tests/kernel/ProjectTest.php
+++ b/tests/kernel/ProjectTest.php
@@ -16,7 +16,7 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
             "aura": {
                 "type": "project",
                 "config": {
-                    "common": "ApplicationConfigCommon",
+                    "common": ["ApplicationConfigCommon", "ApplicationConfigAnotherCommon"],
                     "dev": "ApplicationConfigDev"
                 }
             }
@@ -179,7 +179,8 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
             5 => 'ProjectKernelConfigCommon',
             6 => 'WebKernelConfigCommon',
             7 => 'ApplicationConfigCommon',
-            8 => 'ApplicationConfigDev',
+            8 => 'ApplicationConfigAnotherCommon',
+            9 => 'ApplicationConfigDev',
         );
         $actual = $this->project->getConfigClasses();
         $this->assertSame($expect, $actual);


### PR DESCRIPTION
So something like this might be in a `composer.json`:

```
{
    "extra": { "aura": {
        "type": "project",
        "config": {
            "common": [
                "Acme\\Example\\_Config\\AuraSql",
                "Acme\\Example\\_Config\\Twig"
            ],
            "dev": "Acme\\Example\\_Config\\Dev"
        }
    } }
}
```

A bigger application might want to separate configuration into several
different classes. Normal strings still work, but arrays may be used as
well.
