### PR TITLE
Update to PHPUnit 8.5

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.2', '7.3']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "test": [
             "@composer install",
             "./vendor/bin/phpunit"
-	]
+        ]
     },
     "scripts-descriptions": {
         "test": "Run unit tests"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,4 +7,9 @@
     <php>
         <env name="AURA_CONFIG_MODE" value="kernel" />
     </php>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -142,16 +142,14 @@ class ProjectTest extends \PHPUnit\Framework\TestCase
         $actual = $this->project->getPath();
         $this->assertSame($expect, $actual);
 
-        if (DIRECTORY_SEPARATOR != '\\') {
-            $actual = $this->project->getPath('foo/bar/baz.txt');
-            $expect = $this->path . '/foo/bar/baz.txt';
-            $this->assertSame($expect, $actual);
-        } else {
-            // on Windows
-            $actual = $this->project->getPath('foo\bar\baz.txt');
-            $expect = $this->path . '\foo\bar\baz.txt';
-            $this->assertSame($expect, $actual);
-        }
+        $actual = $this->project->getPath(
+            'foo' . DIRECTORY_SEPARATOR . 'bar'
+            . DIRECTORY_SEPARATOR . 'baz.txt'
+        );
+        $expect = $this->path . DIRECTORY_SEPARATOR . 'foo'
+            . DIRECTORY_SEPARATOR . 'bar'
+            . DIRECTORY_SEPARATOR . 'baz.txt';
+        $this->assertSame($expect, $actual);
     }
 
     public function testGetMode()

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -142,9 +142,16 @@ class ProjectTest extends \PHPUnit\Framework\TestCase
         $actual = $this->project->getPath();
         $this->assertSame($expect, $actual);
 
-        $expect = $this->path . '/foo/bar/baz.txt';
-        $actual = $this->project->getPath('foo/bar/baz.txt');
-        $this->assertSame($expect, $actual);
+        if (DIRECTORY_SEPARATOR != '\\') {
+            $actual = $this->project->getPath('foo/bar/baz.txt');
+            $expect = $this->path . '/foo/bar/baz.txt';
+            $this->assertSame($expect, $actual);
+        } else {
+            // on Windows
+            $actual = $this->project->getPath('foo\bar\baz.txt');
+            $expect = $this->path . '\foo\bar\baz.txt';
+            $this->assertSame($expect, $actual);
+        }
     }
 
     public function testGetMode()

--- a/tests/ProjectTest.php
+++ b/tests/ProjectTest.php
@@ -113,7 +113,7 @@ class ProjectTest extends \PHPUnit\Framework\TestCase
         }
     ]';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->composer = json_decode($this->composer);
         $this->installed = json_decode($this->installed);


### PR DESCRIPTION
PHPUnit 7 can't be installed on php8.
```
  Problem 1
    - phpunit/phpunit[7.0.0, ..., 7.5.20] require php ^7.1 -> your php version (8.0.8) does not satisfy that requirement.
    - Root composer.json requires phpunit/phpunit ~7 -> satisfiable by phpunit/phpunit[7.0.0, ..., 7.5.20].
```

PHPUnit 8 requires php 7.2 or later and supports php8.
(PHPUnit 9 requires php 7.3 or later.)

PHPUnit 8.5 supports Xdebug 3. So updates PHPUnit ^8.5.
